### PR TITLE
Verifier Delete Locks

### DIFF
--- a/RecogLib-iOS/CDocumentWrapper.cpp
+++ b/RecogLib-iOS/CDocumentWrapper.cpp
@@ -11,8 +11,8 @@
 
 using namespace RecogLibC;
 
-std::mutex verifierRenderMutex;
-std::shared_mutex verifierDeleteMutex;
+std::mutex verifierRenderMutex; // Used to prevent verifier methods from running running concurrently, for eg. Reset and ProcessFrame
+std::shared_mutex verifierDeleteMutex; // Used to prevent the verifier from being deleted while a background thread is running
 
 // TODO: Lock each usage of verifier with:
 // std::lock_guard<std::mutex> guard(verifierMutex);

--- a/RecogLib-iOS/CDocumentWrapper.cpp
+++ b/RecogLib-iOS/CDocumentWrapper.cpp
@@ -11,8 +11,8 @@
 
 using namespace RecogLibC;
 
-std::mutex verifierRenderMutex; // Used to prevent verifier methods from running running concurrently, for eg. Reset and ProcessFrame
-std::shared_mutex verifierDeleteMutex; // Used to prevent the verifier from being deleted while a background thread is running
+static std::mutex verifierRenderMutex; // Used to prevent verifier methods from running running concurrently, for eg. Reset and ProcessFrame
+static std::shared_mutex verifierDeleteMutex; // Used to prevent the verifier from being deleted while a background thread is running
 
 // TODO: Lock each usage of verifier with:
 // std::lock_guard<std::mutex> guard(verifierMutex);

--- a/RecogLib-iOS/CFaceLivenessWrapper.cpp
+++ b/RecogLib-iOS/CFaceLivenessWrapper.cpp
@@ -9,8 +9,8 @@
 
 using namespace RecogLibC;
 
-std::mutex verifierRenderMutex; // Used to prevent verifier methods from running running concurrently, for eg. Reset and ProcessFrame
-std::shared_mutex verifierDeleteMutex; // Used to prevent the verifier from being deleted while a background thread is running
+static std::mutex verifierRenderMutex; // Used to prevent verifier methods from running running concurrently, for eg. Reset and ProcessFrame
+static std::shared_mutex verifierDeleteMutex; // Used to prevent the verifier from being deleted while a background thread is running
 
 void * getFaceLivenessVerifier(const char* resourcesPath, CFaceLivenessVerifierSettings *settings)
 {

--- a/RecogLib-iOS/CFaceLivenessWrapper.cpp
+++ b/RecogLib-iOS/CFaceLivenessWrapper.cpp
@@ -9,7 +9,7 @@
 
 using namespace RecogLibC;
 
-static std::mutex verifierRenderMutex; // Used to prevent verifier methods from running running concurrently, for eg. Reset and ProcessFrame
+static std::mutex verifierProcessFrameMutex; // Used to prevent verifier methods from running running concurrently, for eg. Reset and ProcessFrame
 static std::shared_mutex verifierDeleteMutex; // Used to prevent the verifier from being deleted while a background thread is running
 
 void * getFaceLivenessVerifier(const char* resourcesPath, CFaceLivenessVerifierSettings *settings)
@@ -42,7 +42,7 @@ bool verifyFaceLivenessImage(const void *object,
                      CFaceLivenessInfo *face)
 {
     std::shared_lock<std::shared_mutex> shared_lock(verifierDeleteMutex);
-    std::lock_guard<std::mutex> guard(verifierRenderMutex);
+    std::lock_guard<std::mutex> guard(verifierProcessFrameMutex);
     FaceLivenessVerifier *verifier = (FaceLivenessVerifier *)object;
     if (!verifier) throw std::runtime_error("FaceLivenessVerifier is null.");
     
@@ -136,7 +136,7 @@ CFaceLivenessAuxiliaryInfo getAuxiliaryInfo(const void *object)
 void faceLivenessVerifierReset(const void *object)
 {
     std::shared_lock<std::shared_mutex> shared_lock(verifierDeleteMutex);
-    std::lock_guard<std::mutex> guard(verifierRenderMutex);
+    std::lock_guard<std::mutex> guard(verifierProcessFrameMutex);
     FaceLivenessVerifier *verifier = (FaceLivenessVerifier *)object;
     if (!verifier) throw std::runtime_error("FaceLivenessVerifier is null.");
     verifier->Reset();

--- a/RecogLib-iOS/CFaceLivenessWrapper.cpp
+++ b/RecogLib-iOS/CFaceLivenessWrapper.cpp
@@ -9,8 +9,8 @@
 
 using namespace RecogLibC;
 
-std::mutex verifierRenderMutex;
-std::shared_mutex verifierDeleteMutex;
+std::mutex verifierRenderMutex; // Used to prevent verifier methods from running running concurrently, for eg. Reset and ProcessFrame
+std::shared_mutex verifierDeleteMutex; // Used to prevent the verifier from being deleted while a background thread is running
 
 void * getFaceLivenessVerifier(const char* resourcesPath, CFaceLivenessVerifierSettings *settings)
 {


### PR DESCRIPTION
This PR adds locks to prevent accidental deletion of Document and Face Liveness verifiers while member functions are still running on a background thread.

Additionally:
* Added null checks for verifiers
* Prevented calling Reset while the FaceLivenessVerifier::ProcessFrame is running in the background. This is done with locks.